### PR TITLE
Add CoreS3 HelloWorld example

### DIFF
--- a/examples/CoreS3/HelloWorld/HelloWorld.ino
+++ b/examples/CoreS3/HelloWorld/HelloWorld.ino
@@ -1,0 +1,33 @@
+// Include M5Unified library
+#include <M5Unified.h>
+
+void setup() {
+  // Initialize M5Unified for CoreS3
+  auto cfg = M5.config();
+  M5.begin(cfg);
+
+  // Set display brightness (CoreS3 has 320x240 display)
+  M5.Display.setBrightness(128);
+
+  // Clear screen with black background
+  M5.Display.fillScreen(TFT_BLACK);
+
+  // Set text properties
+  M5.Display.setTextColor(TFT_WHITE, TFT_BLACK);
+  M5.Display.setTextDatum(middle_center);
+  M5.Display.setTextSize(3);
+
+  // Display "Hello World" in the center of CoreS3 screen (320x240)
+  M5.Display.drawString("Hello World!", M5.Display.width() / 2, M5.Display.height() / 2);
+
+  // Print to serial monitor
+  Serial.println("Hello World from CoreS3!");
+}
+
+void loop() {
+  // Update M5 state
+  M5.update();
+
+  // Simple delay
+  delay(100);
+}


### PR DESCRIPTION
## Summary

Add a simple HelloWorld example for M5Stack CoreS3 that demonstrates basic display and M5Unified library usage.

## Changes

- Add `examples/CoreS3/HelloWorld/HelloWorld.ino` with:
  - M5Unified library initialization for CoreS3
  - Display brightness and text configuration
  - Center-aligned "Hello World" text display on the 320x240 screen
  - Serial monitor output

## Test plan

- [x] Compile the example for M5Stack CoreS3
- [x] Upload to CoreS3 device
- [x] Verify "Hello World!" displays centered on screen
- [ ] Verify serial output shows "Hello World from CoreS3!"